### PR TITLE
feat(auth): auth domain layer — UserStatus, errors, DTOs, repository port

### DIFF
--- a/src/core/auth/application/dtos/auth.dto.ts
+++ b/src/core/auth/application/dtos/auth.dto.ts
@@ -1,0 +1,33 @@
+import type { UserStatus } from "@/core/auth/domain"
+
+export type RegisterDTO = {
+  name: string
+  email: string
+  password: string
+  universityId: string
+  year: number
+  department?: string
+}
+
+export type ApproveUserDTO = {
+  userId: string
+  adminId: string
+}
+
+export type RejectUserDTO = {
+  userId: string
+  adminId: string
+  reason?: string
+}
+
+export type PendingUserResponseDTO = {
+  id: string
+  name: string
+  email: string
+  universityId: string
+  year: number
+  department: string | null
+  emailVerified: boolean
+  status: UserStatus
+  createdAt: string
+}

--- a/src/core/auth/application/index.ts
+++ b/src/core/auth/application/index.ts
@@ -1,0 +1,8 @@
+export type {
+  RegisterDTO,
+  ApproveUserDTO,
+  RejectUserDTO,
+  PendingUserResponseDTO,
+} from "./dtos/auth.dto"
+
+export type { AuthRepository } from "./ports/auth-repository.port"

--- a/src/core/auth/application/ports/auth-repository.port.ts
+++ b/src/core/auth/application/ports/auth-repository.port.ts
@@ -1,0 +1,9 @@
+import type { PendingUserResponseDTO } from "@/core/auth/application/dtos/auth.dto"
+
+export type AuthRepository = {
+  getPendingUsers: () => Promise<PendingUserResponseDTO[]>
+  approveUser: (userId: string) => Promise<void>
+  rejectUser: (userId: string, reason?: string) => Promise<void>
+  isUserApproved: (userId: string) => Promise<boolean>
+  getUserById: (userId: string) => Promise<PendingUserResponseDTO | null>
+}

--- a/src/core/auth/domain/auth.errors.ts
+++ b/src/core/auth/domain/auth.errors.ts
@@ -1,0 +1,31 @@
+import { DomainError } from "@/core/shared"
+
+export class EmailNotVerifiedError extends DomainError {
+  constructor(userId: string) {
+    super(
+      `User "${userId}" has not verified their email address`,
+      "EMAIL_NOT_VERIFIED",
+    )
+    this.name = "EmailNotVerifiedError"
+  }
+}
+
+export class UserNotApprovedError extends DomainError {
+  constructor(userId: string) {
+    super(
+      `User "${userId}" has not been approved by an administrator`,
+      "USER_NOT_APPROVED",
+    )
+    this.name = "UserNotApprovedError"
+  }
+}
+
+export class UserAlreadyApprovedError extends DomainError {
+  constructor(userId: string) {
+    super(
+      `User "${userId}" is already approved`,
+      "USER_ALREADY_APPROVED",
+    )
+    this.name = "UserAlreadyApprovedError"
+  }
+}

--- a/src/core/auth/domain/index.ts
+++ b/src/core/auth/domain/index.ts
@@ -1,0 +1,6 @@
+export { UserStatus } from "./user-status.enum"
+export {
+  EmailNotVerifiedError,
+  UserNotApprovedError,
+  UserAlreadyApprovedError,
+} from "./auth.errors"

--- a/src/core/auth/domain/user-status.enum.ts
+++ b/src/core/auth/domain/user-status.enum.ts
@@ -1,0 +1,8 @@
+export const UserStatus = {
+  PENDING: "pending",
+  EMAIL_VERIFIED: "email_verified",
+  APPROVED: "approved",
+  REJECTED: "rejected",
+} as const
+
+export type UserStatus = (typeof UserStatus)[keyof typeof UserStatus]

--- a/src/core/auth/index.ts
+++ b/src/core/auth/index.ts
@@ -1,0 +1,14 @@
+export {
+  UserStatus,
+  EmailNotVerifiedError,
+  UserNotApprovedError,
+  UserAlreadyApprovedError,
+} from "./domain"
+
+export type {
+  RegisterDTO,
+  ApproveUserDTO,
+  RejectUserDTO,
+  PendingUserResponseDTO,
+  AuthRepository,
+} from "./application"


### PR DESCRIPTION
## Summary
- Add `UserStatus` enum with pending, email_verified, approved, rejected states
- Add domain errors: `EmailNotVerifiedError`, `UserNotApprovedError`, `UserAlreadyApprovedError`
- Add auth DTOs: `RegisterDTO`, `ApproveUserDTO`, `RejectUserDTO`, `PendingUserResponseDTO`
- Add `AuthRepository` port interface for user approval operations
- Add barrel exports for domain, application, and feature layers

## Test plan
- [ ] Verify all types are importable from `@/core/auth`
- [ ] Verify domain errors extend `DomainError` from shared

Made with [Cursor](https://cursor.com)