### PR TITLE
feat(auth): user approval use cases, MongoDB repository, and admin API routes

### DIFF
--- a/src/app/api/v1/admin/users/[id]/approve/route.ts
+++ b/src/app/api/v1/admin/users/[id]/approve/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server"
+import type { NextRequest } from "next/server"
+import { auth } from "@/core/auth/infrastructure/config/auth"
+import { approveUser, rejectUser } from "@/core/shared/infrastructure/config/dependencies"
+import { UserAlreadyApprovedError } from "@/core/auth"
+import { headers } from "next/headers"
+
+type RouteParams = {
+  params: Promise<{ id: string }>
+}
+
+export const POST = async (request: NextRequest, { params }: RouteParams) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    })
+
+    if (!session || session.user.role !== "admin") {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 403 },
+      )
+    }
+
+    const { id: userId } = await params
+    const body = await request.json() as { action: "approve" | "reject", reason?: string }
+
+    if (!body.action || !["approve", "reject"].includes(body.action)) {
+      return NextResponse.json(
+        { error: "Invalid action. Must be 'approve' or 'reject'" },
+        { status: 400 },
+      )
+    }
+
+    if (body.action === "approve") {
+      await approveUser({ userId, adminId: session.user.id })
+    } else {
+      await rejectUser({ userId, adminId: session.user.id, reason: body.reason })
+    }
+
+    return NextResponse.json(
+      { message: `User ${body.action}d successfully` },
+      { status: 200 },
+    )
+  } catch (error) {
+    if (error instanceof UserAlreadyApprovedError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 409 },
+      )
+    }
+
+    console.error("POST /api/v1/admin/users/[id]/approve error:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/v1/admin/users/route.ts
+++ b/src/app/api/v1/admin/users/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server"
+import { auth } from "@/core/auth/infrastructure/config/auth"
+import { getPendingUsers } from "@/core/shared/infrastructure/config/dependencies"
+import { headers } from "next/headers"
+
+export const GET = async () => {
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    })
+
+    if (!session || session.user.role !== "admin") {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 403 },
+      )
+    }
+
+    const users = await getPendingUsers()
+    return NextResponse.json({ data: users }, { status: 200 })
+  } catch (error) {
+    console.error("GET /api/v1/admin/users error:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    )
+  }
+}

--- a/src/core/auth/application/index.ts
+++ b/src/core/auth/application/index.ts
@@ -6,3 +6,12 @@ export type {
 } from "./dtos/auth.dto"
 
 export type { AuthRepository } from "./ports/auth-repository.port"
+
+export { createApproveUserUseCase } from "./use-cases/approve-user.use-case"
+export type { ApproveUserDependencies } from "./use-cases/approve-user.use-case"
+
+export { createRejectUserUseCase } from "./use-cases/reject-user.use-case"
+export type { RejectUserDependencies } from "./use-cases/reject-user.use-case"
+
+export { createGetPendingUsersUseCase } from "./use-cases/get-pending-users.use-case"
+export type { GetPendingUsersDependencies } from "./use-cases/get-pending-users.use-case"

--- a/src/core/auth/application/use-cases/approve-user.use-case.ts
+++ b/src/core/auth/application/use-cases/approve-user.use-case.ts
@@ -1,0 +1,18 @@
+import type { AuthRepository } from "@/core/auth/application/ports/auth-repository.port"
+import type { ApproveUserDTO } from "@/core/auth/application/dtos/auth.dto"
+import { UserAlreadyApprovedError } from "@/core/auth/domain"
+
+export type ApproveUserDependencies = {
+  authRepository: AuthRepository
+}
+
+export const createApproveUserUseCase = (deps: ApproveUserDependencies) => {
+  return async (dto: ApproveUserDTO): Promise<void> => {
+    const isApproved = await deps.authRepository.isUserApproved(dto.userId)
+    if (isApproved) {
+      throw new UserAlreadyApprovedError(dto.userId)
+    }
+
+    await deps.authRepository.approveUser(dto.userId)
+  }
+}

--- a/src/core/auth/application/use-cases/get-pending-users.use-case.ts
+++ b/src/core/auth/application/use-cases/get-pending-users.use-case.ts
@@ -1,0 +1,12 @@
+import type { AuthRepository } from "@/core/auth/application/ports/auth-repository.port"
+import type { PendingUserResponseDTO } from "@/core/auth/application/dtos/auth.dto"
+
+export type GetPendingUsersDependencies = {
+  authRepository: AuthRepository
+}
+
+export const createGetPendingUsersUseCase = (deps: GetPendingUsersDependencies) => {
+  return async (): Promise<PendingUserResponseDTO[]> => {
+    return deps.authRepository.getPendingUsers()
+  }
+}

--- a/src/core/auth/application/use-cases/reject-user.use-case.ts
+++ b/src/core/auth/application/use-cases/reject-user.use-case.ts
@@ -1,0 +1,12 @@
+import type { AuthRepository } from "@/core/auth/application/ports/auth-repository.port"
+import type { RejectUserDTO } from "@/core/auth/application/dtos/auth.dto"
+
+export type RejectUserDependencies = {
+  authRepository: AuthRepository
+}
+
+export const createRejectUserUseCase = (deps: RejectUserDependencies) => {
+  return async (dto: RejectUserDTO): Promise<void> => {
+    await deps.authRepository.rejectUser(dto.userId, dto.reason)
+  }
+}

--- a/src/core/auth/index.ts
+++ b/src/core/auth/index.ts
@@ -12,3 +12,11 @@ export type {
   PendingUserResponseDTO,
   AuthRepository,
 } from "./application"
+
+export {
+  createApproveUserUseCase,
+  createRejectUserUseCase,
+  createGetPendingUsersUseCase,
+} from "./application"
+
+export { createMongodbAuthRepository } from "./infrastructure/repositories/mongodb-auth.repository"

--- a/src/core/auth/infrastructure/repositories/mongodb-auth.repository.ts
+++ b/src/core/auth/infrastructure/repositories/mongodb-auth.repository.ts
@@ -1,0 +1,74 @@
+import type { AuthRepository } from "@/core/auth/application/ports/auth-repository.port"
+import type { PendingUserResponseDTO } from "@/core/auth/application/dtos/auth.dto"
+import { UserStatus } from "@/core/auth/domain"
+import { MongoClient } from "mongodb"
+
+export const createMongodbAuthRepository = (client: MongoClient): AuthRepository => {
+  const db = client.db()
+  const users = db.collection("user")
+
+  return {
+    getPendingUsers: async (): Promise<PendingUserResponseDTO[]> => {
+      const pending = await users
+        .find({ approved: { $ne: true }, emailVerified: true })
+        .sort({ createdAt: -1 })
+        .toArray()
+
+      return pending.map((user) => ({
+        id: user._id as unknown as string,
+        name: user.name as string,
+        email: user.email as string,
+        universityId: user.universityId as string,
+        year: user.year as number,
+        department: (user.department as string) ?? null,
+        emailVerified: true,
+        status: UserStatus.EMAIL_VERIFIED,
+        createdAt: (user.createdAt as Date)?.toISOString() ?? new Date().toISOString(),
+      }))
+    },
+
+    approveUser: async (userId: string): Promise<void> => {
+      await users.updateOne(
+        { _id: userId as unknown as import("mongodb").ObjectId },
+        { $set: { approved: true } },
+      )
+    },
+
+    rejectUser: async (userId: string, reason?: string): Promise<void> => {
+      await users.updateOne(
+        { _id: userId as unknown as import("mongodb").ObjectId },
+        { $set: { approved: false, rejectionReason: reason ?? null } },
+      )
+    },
+
+    isUserApproved: async (userId: string): Promise<boolean> => {
+      const user = await users.findOne({
+        _id: userId as unknown as import("mongodb").ObjectId,
+      })
+      return user?.approved === true
+    },
+
+    getUserById: async (userId: string): Promise<PendingUserResponseDTO | null> => {
+      const user = await users.findOne({
+        _id: userId as unknown as import("mongodb").ObjectId,
+      })
+      if (!user) return null
+
+      return {
+        id: user._id as unknown as string,
+        name: user.name as string,
+        email: user.email as string,
+        universityId: user.universityId as string,
+        year: user.year as number,
+        department: (user.department as string) ?? null,
+        emailVerified: user.emailVerified as boolean,
+        status: user.approved
+          ? UserStatus.APPROVED
+          : user.emailVerified
+            ? UserStatus.EMAIL_VERIFIED
+            : UserStatus.PENDING,
+        createdAt: (user.createdAt as Date)?.toISOString() ?? new Date().toISOString(),
+      }
+    },
+  }
+}

--- a/src/core/shared/infrastructure/config/dependencies.ts
+++ b/src/core/shared/infrastructure/config/dependencies.ts
@@ -4,14 +4,13 @@ import {
   createGetTasksUseCase,
   createInMemoryTaskRepository,
 } from "@/core/tasks"
-
-/**
- * Composition root: wire all feature dependencies here.
- * Swap implementations (e.g., InMemory -> Supabase) without touching use cases.
- *
- * Each feature module provides its own repository factory and use case factories.
- * This file is the only place where infrastructure meets application.
- */
+import {
+  createApproveUserUseCase,
+  createRejectUserUseCase,
+  createGetPendingUsersUseCase,
+  createMongodbAuthRepository,
+} from "@/core/auth"
+import { MongoClient } from "mongodb"
 
 // ─── Shared Infrastructure ───────────────────────────────────
 const idGenerator = cryptoIdGenerator
@@ -21,3 +20,11 @@ const taskRepository = createInMemoryTaskRepository()
 
 export const createTask = createCreateTaskUseCase({ taskRepository, idGenerator })
 export const getTasks = createGetTasksUseCase({ taskRepository })
+
+// ─── Auth Feature ────────────────────────────────────────────
+const mongoClient = new MongoClient(process.env.MONGODB_URI!)
+const authRepository = createMongodbAuthRepository(mongoClient)
+
+export const approveUser = createApproveUserUseCase({ authRepository })
+export const rejectUser = createRejectUserUseCase({ authRepository })
+export const getPendingUsers = createGetPendingUsersUseCase({ authRepository })


### PR DESCRIPTION
## Summary
- Add `approveUser`, `rejectUser`, `getPendingUsers` use cases following factory function pattern
- Implement `MongodbAuthRepository` with MongoDB queries for pending user management
- Add admin API routes: `GET /api/v1/admin/users` (list pending) and `POST /api/v1/admin/users/[id]/approve` (approve/reject)
- Wire auth dependencies in the composition root (`dependencies.ts`)

## Test plan
- [ ] Verify GET /api/v1/admin/users returns only pending, email-verified users
- [ ] Verify POST approve/reject updates user status correctly
- [ ] Verify non-admin users get 403 from admin endpoints
- [ ] Verify already-approved users return 409 conflict

Made with [Cursor](https://cursor.com)