### PR TITLE
feat(auth): organization management admin API routes

### DIFF
--- a/src/app/api/v1/admin/organizations/route.ts
+++ b/src/app/api/v1/admin/organizations/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server"
+import type { NextRequest } from "next/server"
+import { auth } from "@/core/auth/infrastructure/config/auth"
+import { headers } from "next/headers"
+
+export const GET = async () => {
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    })
+
+    if (!session || session.user.role !== "admin") {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 403 },
+      )
+    }
+
+    const orgs = await auth.api.listOrganizations({
+      headers: await headers(),
+    })
+
+    return NextResponse.json({ data: orgs }, { status: 200 })
+  } catch (error) {
+    console.error("GET /api/v1/admin/organizations error:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    )
+  }
+}
+
+export const POST = async (request: NextRequest) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    })
+
+    if (!session || session.user.role !== "admin") {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 403 },
+      )
+    }
+
+    const body = await request.json() as {
+      organizationId: string
+      userId: string
+      role: string
+    }
+
+    if (!body.organizationId || !body.userId || !body.role) {
+      return NextResponse.json(
+        { error: "Missing required fields: organizationId, userId, role" },
+        { status: 400 },
+      )
+    }
+
+    await auth.api.addMember({
+      body: {
+        organizationId: body.organizationId,
+        userId: body.userId,
+        role: body.role,
+      },
+    })
+
+    return NextResponse.json(
+      { message: "Member added successfully" },
+      { status: 201 },
+    )
+  } catch (error) {
+    console.error("POST /api/v1/admin/organizations error:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/admin/organizations` to list all organizations (admin only)
- Add `POST /api/v1/admin/organizations` to add a member to an organization with role assignment (admin only)
- Both endpoints guarded by session + admin role verification

## Test plan
- [ ] Verify GET returns list of organizations for admin users
- [ ] Verify POST adds member with correct role to specified organization
- [ ] Verify non-admin users get 403 from both endpoints

Made with [Cursor](https://cursor.com)