### PR TITLE
feat(auth): update auth client and permissions to real access control

### DIFF
--- a/src/core/auth/infrastructure/config/permissions.ts
+++ b/src/core/auth/infrastructure/config/permissions.ts
@@ -1,11 +1,52 @@
-import type { Role } from "better-auth/plugins/access"
+import { createAccessControl } from "better-auth/plugins/access"
+import {
+  defaultStatements,
+  adminAc,
+} from "better-auth/plugins/organization/access"
 
-const role = (name: string) => name as unknown as Role
+export const statement = {
+  ...defaultStatements,
+  announcement: ["create", "read", "update", "delete"],
+  blogPost: ["create", "read", "update", "delete"],
+  task: ["create", "read", "update", "delete", "assign"],
+  learningResource: ["create", "read", "update", "delete"],
+  counseling: ["create", "read"],
+  userManagement: ["approve", "reject", "ban", "promote"],
+} as const
 
-export const roles = {
-  member: role("member"),
-  teacher: role("teacher"),
-  counselor: role("counselor"),
-  generalLeader: role("generalLeader"),
-  platformAdmin: role("platformAdmin"),
-}
+export const ac = createAccessControl(statement)
+
+export const member = ac.newRole({
+  announcement: ["read"],
+  blogPost: ["read"],
+  task: ["read"],
+  learningResource: ["read"],
+})
+
+export const teacher = ac.newRole({
+  announcement: ["read"],
+  blogPost: ["read"],
+  task: ["create", "read", "update", "delete", "assign"],
+  learningResource: ["create", "read", "update", "delete"],
+})
+
+export const counselor = ac.newRole({
+  announcement: ["read"],
+  blogPost: ["read"],
+  counseling: ["create", "read"],
+})
+
+export const generalLeader = ac.newRole({
+  announcement: ["create", "read", "update", "delete"],
+  blogPost: ["create", "read", "update", "delete"],
+})
+
+export const platformAdmin = ac.newRole({
+  ...adminAc.statements,
+  announcement: ["create", "read", "update", "delete"],
+  blogPost: ["create", "read", "update", "delete"],
+  task: ["create", "read", "update", "delete", "assign"],
+  learningResource: ["create", "read", "update", "delete"],
+  counseling: ["create", "read"],
+  userManagement: ["approve", "reject", "ban", "promote"],
+})

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,27 +1,29 @@
-import { roles } from "@/core/auth/infrastructure/config/permissions"
+import {
+  ac,
+  member,
+  teacher,
+  counselor,
+  generalLeader,
+  platformAdmin,
+} from "@/core/auth/infrastructure/config/permissions"
 import { adminClient, organizationClient } from "better-auth/client/plugins"
 import { createAuthClient } from "better-auth/react"
 
 export const authClient = createAuthClient({
-    plugins: [
-        organizationClient({
-            roles: {
-                member: roles.member,
-                teacher: roles.teacher,
-                counselor: roles.counselor,
-                generalLeader: roles.generalLeader,
-                admin: roles.platformAdmin,
-                owner: roles.platformAdmin,
-            },
-        }),
-
-        adminClient({
-            roles: {
-                admin: roles.platformAdmin,
-                user: roles.member,
-            },
-        }),
-    ],
+  plugins: [
+    organizationClient({
+      ac,
+      roles: {
+        member,
+        teacher,
+        counselor,
+        generalLeader,
+        admin: platformAdmin,
+        owner: platformAdmin,
+      },
+    }),
+    adminClient(),
+  ],
 })
 
 export type Session = typeof authClient.$Infer.Session

--- a/src/lib/auth-permission.ts
+++ b/src/lib/auth-permission.ts
@@ -1,1 +1,9 @@
-export { roles } from "@/core/auth/infrastructure/config/permissions"
+export {
+  ac,
+  statement,
+  member,
+  teacher,
+  counselor,
+  generalLeader,
+  platformAdmin,
+} from "@/core/auth/infrastructure/config/permissions"


### PR DESCRIPTION
## Summary
- Replace placeholder role casts in `permissions.ts` with real `createAccessControl` from `better-auth/plugins/access`
- Define proper role objects (member, teacher, counselor, generalLeader, platformAdmin) with actual permission statements
- Update `auth-client.ts` to pass `ac` instance to `organizationClient` plugin
- Update `auth-permission.ts` to re-export all access control objects

## Test plan
- [ ] Verify auth client initializes without errors
- [ ] Verify role-based access checks work with the real access control objects

Made with [Cursor](https://cursor.com)