### PR TITLE
feat(admin): user approval dashboard with approve/reject actions

### DIFF
--- a/src/app/(dashboard)/admin/users/page.tsx
+++ b/src/app/(dashboard)/admin/users/page.tsx
@@ -1,0 +1,44 @@
+import { redirect } from "next/navigation"
+import { headers } from "next/headers"
+import { UserApprovalPanel } from "@/features/admin"
+
+const getPendingUsers = async () => {
+  const headersList = await headers()
+  const cookie = headersList.get("cookie") ?? ""
+
+  const baseUrl = process.env.BETTER_AUTH_URL || "http://localhost:3000"
+  const res = await fetch(`${baseUrl}/api/v1/admin/users`, {
+    headers: { cookie },
+    cache: "no-store",
+  })
+
+  if (res.status === 403) {
+    redirect("/")
+  }
+
+  if (!res.ok) {
+    return []
+  }
+
+  const json = await res.json()
+  return json.data ?? []
+}
+
+export default async function AdminUsersPage() {
+  const pendingUsers = await getPendingUsers()
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-2xl font-extrabold tracking-tight text-slate-900 sm:text-3xl">
+          User Approval
+        </h1>
+        <p className="mt-2 text-sm text-slate-500 sm:text-base">
+          Review and approve pending user registrations.
+        </p>
+      </div>
+
+      <UserApprovalPanel initialUsers={pendingUsers} />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link"
+import { Logo } from "@/components/ui"
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-50">
+      <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/80 backdrop-blur-lg">
+        <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+          <Link href="/" aria-label="Home" tabIndex={0}>
+            <Logo variant="full" size="sm" />
+          </Link>
+          <nav className="flex items-center gap-6" aria-label="Dashboard navigation">
+            <Link
+              href="/admin/users"
+              className="text-sm font-semibold text-slate-600 transition-colors hover:text-blue-600"
+              tabIndex={0}
+              aria-label="User Management"
+            >
+              Users
+            </Link>
+            <Link
+              href="/admin/organizations"
+              className="text-sm font-semibold text-slate-600 transition-colors hover:text-blue-600"
+              tabIndex={0}
+              aria-label="Organization Management"
+            >
+              Organizations
+            </Link>
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
+        {children}
+      </main>
+    </div>
+  )
+}

--- a/src/features/admin/components/reject-reason-modal.tsx
+++ b/src/features/admin/components/reject-reason-modal.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useState, useRef, useEffect } from "react"
+import { X } from "lucide-react"
+
+type RejectReasonModalProps = {
+  userName: string
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: (reason: string) => void
+  isLoading: boolean
+}
+
+export const RejectReasonModal = ({
+  userName,
+  isOpen,
+  onClose,
+  onConfirm,
+  isLoading,
+}: RejectReasonModalProps) => {
+  const [reason, setReason] = useState("")
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      setReason("")
+      setTimeout(() => inputRef.current?.focus(), 100)
+    }
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onConfirm(reason)
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="reject-modal-title"
+    >
+      <div
+        className="relative w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl sm:p-8"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 rounded-lg p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
+          aria-label="Close modal"
+          tabIndex={0}
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        <h2
+          id="reject-modal-title"
+          className="text-lg font-bold text-slate-900"
+        >
+          Reject {userName}
+        </h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Provide a reason for rejecting this user&apos;s account (optional).
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-4">
+          <textarea
+            ref={inputRef}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Reason for rejection…"
+            rows={3}
+            className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 transition-all placeholder:text-slate-400 focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-4 focus:ring-blue-500/10"
+            aria-label="Rejection reason"
+          />
+
+          <div className="mt-4 flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition-all hover:bg-slate-50"
+              tabIndex={0}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="flex-1 rounded-xl bg-red-600 px-4 py-2.5 text-sm font-semibold text-white transition-all hover:bg-red-700 disabled:opacity-50"
+              tabIndex={0}
+            >
+              {isLoading ? "Rejecting…" : "Reject User"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/features/admin/components/user-approval-panel.tsx
+++ b/src/features/admin/components/user-approval-panel.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import { useState } from "react"
+import { CheckCircle, XCircle, Users, Loader2 } from "lucide-react"
+import { RejectReasonModal } from "./reject-reason-modal"
+
+type PendingUser = {
+  id: string
+  name: string
+  email: string
+  universityId: string
+  year: number
+  department: string | null
+  createdAt: string
+}
+
+type UserApprovalPanelProps = {
+  initialUsers: PendingUser[]
+}
+
+export const UserApprovalPanel = ({ initialUsers }: UserApprovalPanelProps) => {
+  const [users, setUsers] = useState<PendingUser[]>(initialUsers)
+  const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({})
+  const [rejectTarget, setRejectTarget] = useState<PendingUser | null>(null)
+  const [feedback, setFeedback] = useState<{ type: "success" | "error", message: string } | null>(null)
+
+  const handleApprove = async (userId: string) => {
+    setActionLoading((prev) => ({ ...prev, [userId]: true }))
+    setFeedback(null)
+
+    try {
+      const res = await fetch(`/api/v1/admin/users/${userId}/approve`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "approve" }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json()
+        setFeedback({ type: "error", message: data.error || "Failed to approve user" })
+        return
+      }
+
+      setUsers((prev) => prev.filter((u) => u.id !== userId))
+      setFeedback({ type: "success", message: "User approved successfully" })
+    } catch {
+      setFeedback({ type: "error", message: "Network error. Please try again." })
+    } finally {
+      setActionLoading((prev) => ({ ...prev, [userId]: false }))
+    }
+  }
+
+  const handleReject = async (userId: string, reason: string) => {
+    setActionLoading((prev) => ({ ...prev, [userId]: true }))
+    setFeedback(null)
+
+    try {
+      const res = await fetch(`/api/v1/admin/users/${userId}/approve`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "reject", reason }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json()
+        setFeedback({ type: "error", message: data.error || "Failed to reject user" })
+        return
+      }
+
+      setUsers((prev) => prev.filter((u) => u.id !== userId))
+      setRejectTarget(null)
+      setFeedback({ type: "success", message: "User rejected" })
+    } catch {
+      setFeedback({ type: "error", message: "Network error. Please try again." })
+    } finally {
+      setActionLoading((prev) => ({ ...prev, [userId]: false }))
+    }
+  }
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    })
+  }
+
+  if (users.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-white px-8 py-16">
+        <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-slate-100">
+          <Users className="h-8 w-8 text-slate-400" />
+        </div>
+        <h3 className="text-lg font-bold text-slate-700">No Pending Users</h3>
+        <p className="mt-1 text-sm text-slate-500">All user accounts have been reviewed.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {feedback && (
+        <div
+          role="alert"
+          className={`mb-4 rounded-xl border px-4 py-3 text-sm font-medium ${
+            feedback.type === "success"
+              ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+              : "border-red-200 bg-red-50 text-red-700"
+          }`}
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 bg-slate-50">
+                <th className="px-6 py-3.5 font-semibold text-slate-600">Name</th>
+                <th className="px-6 py-3.5 font-semibold text-slate-600">Email</th>
+                <th className="px-6 py-3.5 font-semibold text-slate-600">University ID</th>
+                <th className="px-6 py-3.5 font-semibold text-slate-600">Year</th>
+                <th className="px-6 py-3.5 font-semibold text-slate-600">Department</th>
+                <th className="px-6 py-3.5 font-semibold text-slate-600">Registered</th>
+                <th className="px-6 py-3.5 font-semibold text-slate-600">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((user) => (
+                <tr
+                  key={user.id}
+                  className="border-b border-slate-100 transition-colors last:border-0 hover:bg-slate-50"
+                >
+                  <td className="whitespace-nowrap px-6 py-4 font-medium text-slate-900">
+                    {user.name}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-slate-600">
+                    {user.email}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 font-mono text-sm text-slate-600">
+                    {user.universityId}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-slate-600">
+                    Year {user.year}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-slate-600">
+                    {user.department || "—"}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-slate-500">
+                    {formatDate(user.createdAt)}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleApprove(user.id)}
+                        disabled={actionLoading[user.id]}
+                        className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700 transition-all hover:bg-emerald-100 disabled:opacity-50"
+                        tabIndex={0}
+                        aria-label={`Approve ${user.name}`}
+                      >
+                        {actionLoading[user.id] ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <CheckCircle className="h-3.5 w-3.5" />
+                        )}
+                        Approve
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setRejectTarget(user)}
+                        disabled={actionLoading[user.id]}
+                        className="inline-flex items-center gap-1.5 rounded-lg bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-700 transition-all hover:bg-red-100 disabled:opacity-50"
+                        tabIndex={0}
+                        aria-label={`Reject ${user.name}`}
+                      >
+                        <XCircle className="h-3.5 w-3.5" />
+                        Reject
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <RejectReasonModal
+        userName={rejectTarget?.name ?? ""}
+        isOpen={rejectTarget !== null}
+        onClose={() => setRejectTarget(null)}
+        onConfirm={(reason) => {
+          if (rejectTarget) handleReject(rejectTarget.id, reason)
+        }}
+        isLoading={rejectTarget ? actionLoading[rejectTarget.id] ?? false : false}
+      />
+    </div>
+  )
+}

--- a/src/features/admin/index.ts
+++ b/src/features/admin/index.ts
@@ -1,0 +1,2 @@
+export { UserApprovalPanel } from "./components/user-approval-panel"
+export { RejectReasonModal } from "./components/reject-reason-modal"


### PR DESCRIPTION
## Summary
- Add dashboard layout shell (`(dashboard)/layout.tsx`) with navigation header (Users, Organizations links)
- Add admin users page as server component that fetches pending users and redirects non-admins
- Add `UserApprovalPanel` with table displaying name, email, university ID, year, department, registration date
- Add approve/reject action buttons with loading states and success/error feedback
- Add `RejectReasonModal` dialog for providing rejection reason
- Add empty state when no pending users exist
- Create `features/admin` barrel export

## Test plan
- [ ] Verify admin users page loads pending users in table
- [ ] Verify approve button sends POST and removes user from table
- [ ] Verify reject button opens modal, submits reason, removes user
- [ ] Verify non-admin users get redirected to home
- [ ] Verify empty state shows when no pending users

Made with [Cursor](https://cursor.com)